### PR TITLE
Move VS Project Files & Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 extract-xiso
 *.o
 *.a
+*.user
+.vs/
+bin/

--- a/extract-xiso.sln
+++ b/extract-xiso.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2020
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "extract-xiso", "visual_c++_project.vcxproj", "{A6AE4B10-E96A-437D-A5A2-E4868EC1C55C}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "extract-xiso", "extract-xiso.vcxproj", "{A6AE4B10-E96A-437D-A5A2-E4868EC1C55C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/extract-xiso.vcxproj
+++ b/extract-xiso.vcxproj
@@ -41,13 +41,13 @@
     <_ProjectFileVersion>15.0.27130.2020</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Debug\</OutDir>
-    <IntDir>Debug\</IntDir>
+    <OutDir>bin\Debug\</OutDir>
+    <IntDir>bin\Debug\</IntDir>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Release\</OutDir>
-    <IntDir>Release\</IntDir>
+    <OutDir>bin\Release\</OutDir>
+    <IntDir>bin\Release\</IntDir>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -64,7 +64,7 @@
     <Link>
       <OutputFile>%(OutputFile)</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>$(OutDir)visual_c++_project.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>$(OutDir)extract-xiso.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -96,7 +96,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\extract-xiso.c" />
+    <ClCompile Include="extract-xiso.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/extract-xiso.vcxproj.filters
+++ b/extract-xiso.vcxproj.filters
@@ -7,7 +7,7 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\extract-xiso.c">
+    <ClCompile Include="extract-xiso.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
The previous way the Visual Studio project files were implemented were annoying.

When building, files now goto $current_dir/bin/$release_type.