### PR TITLE
Define _GNU_SOURCE in Linux

### DIFF
--- a/extract-xiso.c
+++ b/extract-xiso.c
@@ -237,6 +237,9 @@
 #if defined( __LINUX__ )
 	#define _LARGEFILE64_SOURCE
 #endif
+#if defined( __GNUC__ )
+	#define _GNU_SOURCE
+#endif
 
 
 #include <time.h>


### PR DESCRIPTION
Silences an asprintf() warning.