### PR TITLE
Use off64_t instead of __off64_t on Linux

### DIFF
--- a/extract-xiso.c
+++ b/extract-xiso.c
@@ -302,7 +302,7 @@
 	#define lseek						lseek64
 	#define stat						stat64
 	
-	typedef __off64_t					xoff_t;
+	typedef off64_t 					xoff_t;
 #elif defined( __OPENBSD__ )
 	#define exiso_target				"openbsd"
 #elif defined( _WIN32 )


### PR DESCRIPTION
__off64_t seems to be a glibc-specific type, while off64_t is the type mentioned in the GNU docs. I noticed this while playing around with Alpine Linux, which uses musl instead of glibc, as musl does not have __off64_t.

Building worked fine afterwards on Arch (x86_64), Alpine (x86_64) and Ubuntu (x86).