### PR TITLE
Fix compilation on msys2/mingw

### DIFF
--- a/extract-xiso.c
+++ b/extract-xiso.c
@@ -323,8 +323,9 @@
 	#define S_ISREG( x )				( ( x ) & _S_IFREG )
 
 	#include "win32/getopt.c"
+#ifdef _MSC_VER
 	#include "win32/asprintf.c"
-	
+#endif
 	#define lseek						_lseeki64
 	#define mkdir( a, b )				mkdir( a )
 


### PR DESCRIPTION
Compilation on msys2/mingw was broken due to multiple conflicting definitions/declarations of asprintf. Fixed by disabling the included asprintf when non-MSVC is detected on Windows.