### PR TITLE
Fix project name in AppVeyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ before_build:
     cd build
     cmake .. -G "Visual Studio 15 2017"
 build:
-  project: c:\projects\extract-xiso\build\Project.sln
+  project: c:\projects\extract-xiso\build\extract-xiso.sln
 after_build:
 - cmd: |-
     cd %CONFIGURATION%


### PR DESCRIPTION
#35 broke CI by assigning a project name in the CMake config but not adjusting the name of the VS Solution file generated by CMake. This fixes it by updating that filename.