### PR TITLE
Fix edge cases with some ISO files, and simplify the code a bit

### DIFF
--- a/extract-xiso.c
+++ b/extract-xiso.c
@@ -999,8 +999,6 @@ int create_xiso( char *in_root_directory, char *in_output_directory, dir_node_av
 		
 		s_total_bytes = s_total_files = 0;
 		
-		if ( root.subdirectory == EMPTY_SUBDIRECTORY ) root.start_sector = root.file_size = 0;
-		
 		start_sector = root.start_sector;
 		
 		avl_traverse_depth_first( &root, (traversal_callback) calculate_directory_requirements, nil, k_prefix, 0 );
@@ -1047,7 +1045,7 @@ int create_xiso( char *in_root_directory, char *in_output_directory, dir_node_av
 	}
 	if ( ! err && ( root.filename = strdup( iso_dir ) ) == nil ) mem_err();
 
-	if ( ! err && root.start_sector && lseek( xiso, (xoff_t) root.start_sector * XISO_SECTOR_SIZE, SEEK_SET ) == -1 ) seek_err();
+	if ( ! err && lseek( xiso, (xoff_t) root.start_sector * XISO_SECTOR_SIZE, SEEK_SET ) == -1 ) seek_err();
 	if ( ! err ) {
 		wt_context.path = nil;
 		wt_context.xiso = xiso;

--- a/extract-xiso.c
+++ b/extract-xiso.c
@@ -266,6 +266,13 @@
 	#include <unistd.h>
 #endif
 
+#if defined(_MSC_VER)
+	#define strcasecmp	_stricmp
+	#define strncasecmp	_strnicmp
+#else
+	#include <strings.h>
+#endif
+
 
 #if defined( __DARWIN__ )
 	#define exiso_target				"macos-x"
@@ -323,7 +330,7 @@
 	#define S_ISREG( x )				( ( x ) & _S_IFREG )
 
 	#include "win32/getopt.c"
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
 	#include "win32/asprintf.c"
 #endif
 	#define lseek						_lseeki64
@@ -1110,7 +1117,7 @@ int decode_xiso( char *in_xiso, char *in_path, modes in_mode, char **out_iso_pat
 		len = (int) strlen( name );
 
 		// create a directory of the same name as the file we are working on, minus the ".iso" portion
-		if ( len > 4 && name[ len - 4 ] == '.' && ( name[ len - 3 ] | 0x20 ) == 'i' && ( name[ len - 2 ] | 0x20 ) == 's' && ( name[ len - 1 ] | 0x20 ) == 'o' ) {
+		if (len > 4 && strcasecmp(&name[len - 4], ".iso") == 0) {
 			name[ len -= 4 ] = 0;
 			if ( ( short_name = strdup( name ) ) == nil ) mem_err();
 			name[ len ] = '.';
@@ -1785,7 +1792,7 @@ int write_file( dir_node_avl *in_avl, write_tree_context *in_context, int in_dep
 					break;
 				}
 				bytes -= n;
-				if (s_media_enable && (len = strlen(in_avl->filename)) >= 4 && in_avl->filename[len - 4] == '.' && (in_avl->filename[len - 3] | 0x20) == 'x' && (in_avl->filename[len - 2] | 0x20) == 'b' && (in_avl->filename[len - 1] | 0x20) == 'e') {
+				if (s_media_enable && (len = strlen(in_avl->filename)) >= 4 && strcasecmp(&in_avl->filename[len - 4], ".xbe") == 0) {
 					for (buf[n += i] = 0, p = buf; (p = boyer_moore_search(p, n - (p - buf))) != nil; p += XISO_MEDIA_ENABLE_LENGTH) p[XISO_MEDIA_ENABLE_BYTE_POS] = XISO_MEDIA_ENABLE_BYTE;
 					if (bytes) {
 						i = XISO_MEDIA_ENABLE_LENGTH - 1;

--- a/extract-xiso.c
+++ b/extract-xiso.c
@@ -1294,7 +1294,7 @@ left_processed:
 			
 				if ( ! err ) {
 					sprintf( path, "%s%s%c", in_path, dir->filename, PATH_CHAR );
-					if ( dir->start_sector && lseek( in_xiso, (xoff_t) dir->start_sector * XISO_SECTOR_SIZE + s_xbox_disc_lseek, SEEK_SET ) == -1 ) seek_err();
+					if ( lseek( in_xiso, (xoff_t) dir->start_sector * XISO_SECTOR_SIZE + s_xbox_disc_lseek, SEEK_SET ) == -1 ) seek_err();
 				}
 			} else path = nil;
 	
@@ -1303,7 +1303,7 @@ left_processed:
 				{
 				if ( in_mode == k_extract ) {
 					if ( ( err = mkdir( dir->filename, 0755 ) ) ) mkdir_err( dir->filename );
-					if ( ! err && dir->start_sector && ( err = chdir( dir->filename ) ) ) chdir_err( dir->filename );
+					if ( ! err && ( err = chdir( dir->filename ) ) ) chdir_err( dir->filename );
 				}
 				if( ! err && in_mode != k_generate_avl ) {
 					exiso_log("%s%s%s%s (0 bytes)%s", in_mode == k_extract ? "creating " : "", in_path, dir->filename, PATH_CHAR_STR, in_mode == k_extract ? " [OK]" : ""); flush();
@@ -1312,7 +1312,7 @@ left_processed:
 			}
 			}
 			
-			if ( ! err && dir->start_sector ) {
+			if ( ! err ) {
 				memcpy( &subdir, dir, sizeof(dir_node) );
 				
 				subdir.parent = nil;


### PR DESCRIPTION
This PR fixes issues #76 and #77.
I also made a change for consistency: d70a913 made empty directories occupy one sector, as seen on retail ISOs, but didn't account for an empty root directory. A bit of an edge case, but now the behavior is consistent.
Finally, I used strcasecmp instead of an hack to check for case insensitive file names, since it's much easier to read.