### PR TITLE
Updating readme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,4 +9,6 @@ set(SOURCE_FILES
 
 add_executable(extract-xiso ${SOURCE_FILES})
 target_compile_definitions(extract-xiso PRIVATE ${TARGET_OS})
+target_compile_options(extract-xiso PUBLIC -m32)
+target_link_options(extract-xiso PUBLIC -m32)
 install(TARGETS extract-xiso RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")

--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ Extract XISO contents to a directory.
 - make
 - gcc
 
-### Linux Requirements
+### Linux Distribution Requirements
 
   #### Fedora
   ```
-sudo dnf install cmake gcc gcc-c++ glibc-devel.i686 -y
+sudo dnf install cmake gcc gcc-c++ glibc-devel.i686 git -y
 ```
   #### Ubuntu
   ```
-sudo apt install gcc-multilib build-essential -y
+sudo apt install gcc-multilib build-essential git -y
 ```
 
 ### Windows / macOS / Linux

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Extract XISO contents to a directory.
 
   #### Fedora
   ```
-sudo dnf install cmake gcc gcc-c++ glibc-devel.i686 git -y
+sudo dnf install cmake gcc gcc-c++ glibc-devel.i686 git -y 
 ```
   #### Ubuntu
   ```

--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ Extract XISO contents to a directory.
 - make
 - gcc
 
+### Linux Requirements
+
+  #### Fedora
+  ```
+sudo dnf install cmake gcc gcc-c++ glibc-devel.i686 -y
+```
+  #### Ubuntu
+  ```
+sudo apt install gcc-multilib build-essential -y
+```
+
 ### Windows / macOS / Linux
 
 After requirements are installed with your distribution's package manager (or homebrew for macOS), open terminal and change directory to the project root. Then run the following build commands:


### PR DESCRIPTION
Added instructions for Fedora and Ubuntu dependencies for making 64bit and 32bit binaries. On Fedora, cmake will error unless it has "gcc-c++" installed to check against. It's just easier for users to have it installed instead of making seperate build instructions for Fedora.

I'm also new to Github as a whole and haven't really contributed much to many projects, so if things look weird or I didn't request this right, I'm sorry.