### PR TITLE
CI: Reenable 64-bit builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - master
     paths-ignore:
       - '*.md'
       - '*.yml'
@@ -20,7 +22,7 @@ jobs:
         echo "BUILD_TAG=$BUILD_TAG" >> $GITHUB_ENV
         echo -n $BUILD_TAG > tag
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: tag
         path: tag
@@ -55,10 +57,12 @@ jobs:
       run: |
         mkdir artifacts
         mv -vb build\${{ matrix.configuration }}\extract-xiso.exe, LICENSE.TXT artifacts
-    - uses: actions/upload-artifact@v2
+        cd artifacts
+        powershell Compress-Archive . ../extract-xiso-${{ matrix.artifact_os }}_${{ matrix.configuration }}.zip
+    - uses: actions/upload-artifact@v4
       with:
         name: extract-xiso_${{ matrix.artifact_os }}_${{ matrix.configuration }}
-        path: artifacts
+        path: extract-xiso-${{ matrix.artifact_os }}_${{ matrix.configuration }}.zip
 
   build-linux:
     runs-on: ubuntu-latest
@@ -76,10 +80,12 @@ jobs:
       run: |
         mkdir artifacts
         mv -v build/extract-xiso LICENSE.TXT artifacts
-    - uses: actions/upload-artifact@v2
+        cd artifacts
+        zip -r ../extract-xiso_${{ runner.os }}.zip *
+    - uses: actions/upload-artifact@v4
       with:
         name: extract-xiso_${{ runner.os }}
-        path: artifacts
+        path: extract-xiso_${{ runner.os }}.zip
 
   build-macos:
     runs-on: macos-latest
@@ -97,105 +103,30 @@ jobs:
       run: |
         mkdir artifacts
         mv -v build/extract-xiso LICENSE.TXT artifacts
-    - uses: actions/upload-artifact@v2
+        cd artifacts
+        zip -r ../extract-xiso_${{ runner.os }}.zip *
+    - uses: actions/upload-artifact@v4
       with:
         name: extract-xiso_${{ runner.os }}
-        path: artifacts
+        path: extract-xiso_${{ runner.os }}.zip
 
   Release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: [build-windows, build-linux, build-macos]
-    env:
-      BUILD_TAG:
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         path: dist
-    - name: Create archives
-      run: |
-        pushd dist/extract-xiso_Win32_Release
-        zip -r ../extract-xiso-win32-release.zip *
-        popd
-        pushd dist/extract-xiso_Win32_Debug
-        zip -r ../extract-xiso-win32-debug.zip *
-        popd
-        ###
-        # Comment out 64 bit builds as they are currently broken
-        ###
-        # pushd dist/extract-xiso_Win64_Release
-        # zip -r ../extract-xiso-win64-release.zip *
-        # popd
-        # pushd dist/extract-xiso_Win64_Debug
-        # zip -r ../extract-xiso-win64-debug.zip *
-        # popd
-        # pushd dist/extract-xiso_macOS
-        # zip -r ../extract-xiso-macos.zip *
-        # popd
     - name: Get package info
       run: |
         echo "BUILD_TAG=$(cat dist/tag/tag)" >> $GITHUB_ENV
     - name: Create release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ env.BUILD_TAG }}
-        release_name: ${{ env.BUILD_TAG }}
-        draft: false
+        name: ${{ env.BUILD_TAG }}
         prerelease: false
-    - name: Upload release assets (Win32 build)
-      id: upload-release-assets-win32-release
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_name: extract-xiso-win32-release.zip
-        asset_path: dist/extract-xiso-win32-release.zip
-        asset_content_type: application/zip
-    - name: Upload release assets (Win32 debug build)
-      id: upload-release-assets-win32-debug
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_name: extract-xiso-win32-debug.zip
-        asset_path: dist/extract-xiso-win32-debug.zip
-        asset_content_type: application/zip
-    ###
-    # Comment out 64 bit builds as they are currently broken
-    ###
-    # - name: Upload release assets (Win64 build)
-    #   id: upload-release-assets-win64-release
-    #   uses: actions/upload-release-asset@v1.0.1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-    #     asset_name: extract-xiso-win64-release.zip
-    #     asset_path: dist/extract-xiso-win64-release.zip
-    #     asset_content_type: application/zip
-    # - name: Upload release assets (Win64 debug build)
-    #   id: upload-release-assets-win64-debug
-    #   uses: actions/upload-release-asset@v1.0.1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-    #     asset_name: extract-xiso-win64-debug.zip
-    #     asset_path: dist/extract-xiso-win64-debug.zip
-    #     asset_content_type: application/zip
-    # - name: Upload release assets (macOS build)
-    #   id: upload-release-assets-macos-release
-    #   uses: actions/upload-release-asset@v1.0.1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-    #     asset_name: extract-xiso-macos.zip
-    #     asset_path: dist/extract-xiso-macos.zip
-    #     asset_content_type: application/zip
+        draft: false
+        files: dist/*/*.zip


### PR DESCRIPTION
I've tested ISOs of Return To Castle Wolfenstein and Halo 2 Multiplayer Map Pack with both 32 and 64 bit Linux builds of extract-xiso at head and it seems that the only difference left is the expected creation timestamp value.
